### PR TITLE
Allowing the src and test directories into the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,4 @@
 /.travis.yml
 /.npmignore
 
-/src
-/test
 /coverage

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spur-config",
   "description": "Configuration framework to help manage complex application configurations in Node.js.",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "main": "lib/SpurConfig",
   "jsnext:main": "./src/SpurConfig",
   "author": {


### PR DESCRIPTION
Correcting issue when package is referenced from an es6 app. Currently define the main script as:

`"jsnext:main": "./src/SpurConfig",`

However, we had the src directory in the `.npmignore` on the file so the refs wouldn't work and eslint would complain about it.
