### PR TITLE
Updating devDependencies and removing unsupported node versions from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: node_js
 
 node_js:
-- '0.10'
-- '0.11'
-- '0.12'
 - '4'
-- '5'
 - '6'
 
 script: npm run build-and-test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Configuration framework to help manage complex application configurations in [Node.js](http://nodejs.org/).
 
-[![NPM version](https://badge.fury.io/js/spur-config.png)](http://badge.fury.io/js/spur-config) [![Build Status](https://travis-ci.org/opentable/spur-config.png?branch=master)](https://travis-ci.org/opentable/spur-config)
+[![npm version](https://badge.fury.io/js/spur-config.svg)](http://badge.fury.io/js/spur-config)
+[![Build Status](https://travis-ci.org/opentable/spur-config.svg?branch=master)](https://travis-ci.org/opentable/spur-config)
+[![Dependencies](https://david-dm.org/opentable/spur-config.svg)](https://david-dm.org/opentable/spur-config)
+[![devDependency Status](https://david-dm.org/opentable/spur-config/dev-status.svg)](https://david-dm.org/opentable/spur-config?type=dev)
 
 # About the Spur Framework
 
@@ -38,6 +41,8 @@ $ npm install spur-config --save
 ```
 
 ## Usage
+
+Supports active Node versions in the [LTS Schedule](https://github.com/nodejs/LTS#lts-schedule). ([view current versions](.travis.yml))
 
 ### Configuration files
 
@@ -175,6 +180,8 @@ $ npm test
 ```
 
 View the `package.json`'s `scripts` section for a list of all the other commands.
+
+> Requires Node 4+ for dev tools, but we recommend using Node 6.
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -19,14 +19,17 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "babel src -d lib --source-maps",
-    "dev": "babel --watch src -d lib",
+    "clean": "rm -rf lib/",
+    "build": "npm run clean && babel src -d lib --source-maps",
+    "dev": "npm run clean && babel --watch src -d lib",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test-unit": "babel-node --debug node_modules/mocha/bin/_mocha ./test/unit/",
     "test-integration": "babel-node --debug node_modules/mocha/bin/_mocha ./test/integration/",
     "test": "npm run test-unit && npm run test-integration",
-    "build-and-test": "npm run build && npm test"
+    "build-and-test": "npm run build && npm test",
+    "prepublish": "npm run test",
+    "postinstall": "npm run build"
   },
   "bugs": {
     "url": "https://github.com/opentable/spur-config/issues"
@@ -43,15 +46,16 @@
     "require-all": "^2.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.5.1",
+    "babel-cli": "^6.18.0",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-es2015": "^6.5.0",
-    "babel-preset-es2015-loose": "^7.0.0",
+    "babel-plugin-transform-regenerator": "6.16.1",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-es2015-loose": "^8.0.0",
     "chai": "^3.5.0",
-    "eslint": "^2.4.0",
-    "eslint-config-opentable": "^4.0.0",
-    "eslint-plugin-import": "^1.8.1",
-    "mocha": "^2.4.5",
+    "eslint": "^3.13.1",
+    "eslint-config-opentable": "^6.0.0",
+    "eslint-plugin-import": "^2.2.0",
+    "mocha": "^3.2.0",
     "sinon": "^1.17.4"
   }
 }

--- a/src/plugins/extends.js
+++ b/src/plugins/extends.js
@@ -1,5 +1,5 @@
 module.exports = function (...configNames) {
-  configNames.forEach(configName => {
+  configNames.forEach((configName) => {
     const config = this.loadConfig(configName);
     this.deepExtend(config);
   });

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -17,6 +17,8 @@
     "no-unused-expressions": 0,
     "max-len": 0,
     "arrow-body-style": 0,
-    "no-console": 0
+    "no-console": 0,
+    "import/no-extraneous-dependencies": 0,
+    "import/no-unresolved": 0
   }
 }

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,6 +1,7 @@
 global.assert = require('assert');
 global.chai = require('chai');
 global.sinon = require('sinon');
+
 global.expect = global.chai.expect;
 
 process.env.NODE_ENV = 'test';

--- a/test/integration/CoffeeScriptConfigurationSpec.js
+++ b/test/integration/CoffeeScriptConfigurationSpec.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import _ from 'lodash';
+
 const spurConfig = require('../../');
 const expectedData = require('./data/DataExpectations');
 

--- a/test/integration/JavaScriptConfigurationSpec.js
+++ b/test/integration/JavaScriptConfigurationSpec.js
@@ -1,4 +1,5 @@
 import path from 'path';
+
 const spurConfig = require('../../');
 const expectedData = require('./data/DataExpectations');
 


### PR DESCRIPTION

* Removing Node 0.10, 0.11, 0.12, and 5 from .travis.yml to only run tests on supported LTS versions
* Updating devDependencies
* Fixing code related to updating the version of eslint-config-opentable which had a few small changes to the syntax rules
* Adding "babel-plugin-transform-regenerator": "6.16.1" to resolve the build issue