### PR TITLE
Updates the production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "lodash.foreach": "^4.5.0",
         "lodash.isfunction": "^3.0.9",
         "lodash.merge": "^4.6.2",
-        "require-all": "^2.0.0"
+        "require-all": "^3.0.0"
       },
       "devDependencies": {
         "chai": "^4.3.7",
@@ -1639,11 +1639,11 @@
       }
     },
     "node_modules/require-all": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/require-all/-/require-all-2.2.0.tgz",
-      "integrity": "sha1-tEIMIzrAKC0P9Jsnf7iAqLXeCJQ=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/require-all/-/require-all-3.0.0.tgz",
+      "integrity": "sha512-jPGN876lc5exWYrMcgZSd7U42P0PmVQzxnQB13fCSzmyGnqQWW4WUz5DosZ/qe24hz+5o9lSvW2epBNZ1xa6Fw==",
       "engines": {
-        "node": "*"
+        "node": ">= 0.8"
       }
     },
     "node_modules/require-directory": {
@@ -3249,9 +3249,9 @@
       "dev": true
     },
     "require-all": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/require-all/-/require-all-2.2.0.tgz",
-      "integrity": "sha1-tEIMIzrAKC0P9Jsnf7iAqLXeCJQ="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/require-all/-/require-all-3.0.0.tgz",
+      "integrity": "sha512-jPGN876lc5exWYrMcgZSd7U42P0PmVQzxnQB13fCSzmyGnqQWW4WUz5DosZ/qe24hz+5o9lSvW2epBNZ1xa6Fw=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash.foreach": "^4.5.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.merge": "^4.6.2",
-    "require-all": "^2.0.0"
+    "require-all": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^4.3.7",


### PR DESCRIPTION
Updates require-all from 2.x to 3.0. ([release notes](https://github.com/felixge/node-require-all/blob/master/Changes.md#v300-2018-07-02)):

- Drop support for Node.js 0.6 and below
- Skip adding keys for directories without modules

No impact to our usage but keeps the versions updated